### PR TITLE
#10 一覧画面からステータスと優先度の編集

### DIFF
--- a/pages/components/TodoList.js
+++ b/pages/components/TodoList.js
@@ -62,7 +62,8 @@ const TodoList = () => {
 
   // ステータスの実装
 
-  const handleSetNewStatus = (id) => {
+  const handleSetNewStatus = (id,staus) => {
+    
     const foundTodo = todos.findIndex((todo) => todo.id === id);
 
     const replaceItemAtIndex = (todos, foundTodo, newValue) => {
@@ -77,45 +78,37 @@ const TodoList = () => {
       if (todos[foundTodo].status) {
         return replaceItemAtIndex(todos, foundTodo, {
           ...todos[foundTodo],
-          status: "完了",
+          status: staus,
         });
       }
     });
   };
 
+  
   // 優先度の実装
-  const updateTodoPriority = (id) => {
-    const index = todos.find((todo) => todo.id === id);
-    setTodos(() => {});
+  const handleSetNewPriority = (id,priority) => {
+    
+    const foundTodo = todos.findIndex((todo) => todo.id === id);
+    
+    const replaceItemAtIndex = (todos, foundTodo, newValue) => {
+      return [
+        ...todos.slice(0, foundTodo),
+        newValue,
+        ...todos.slice(foundTodo + 1),
+      ];
+    };
+    
+    setTodos(() => {
+      if (todos[foundTodo].priority) {
+        return replaceItemAtIndex(todos, foundTodo, {
+          ...todos[foundTodo],
+          priority: priority,
+        });
+      }
+    });
+    console.log();
   };
-  const handleSetNewPriority = (e) => {
-    setNewPriority(e.target.value);
-  };
-
-  const handleOpenEditPriority = ({ id, priority }) => {
-    setEditId(id);
-    setIsEditable(true);
-    setNewPriority(priority);
-  };
-
-  const handleCloseEditPriority = () => {
-    setIsEditable(false);
-    setEditId();
-    setNewStatus();
-  };
-
-  // 編集フォームへの値のコピー
-  const handleEditPriority = () => {
-    setTodos(
-      [...todos].map((todo) =>
-        todo.id === editId ? { ...todo, priority: newPriority } : todo
-      )
-    );
-
-    handleCloseEditPriority();
-    setEditId();
-    setNewPriority();
-  };
+  
   console.log(todos);
 
   return (
@@ -155,8 +148,8 @@ const TodoList = () => {
 
                 <Td color={renderStatus(todo)}>
                   <select
-                    // value={}
-                    onChange={(e) => handleSetNewStatus(todo.id)}
+                    value={todo.status}
+                    onChange={(e) => handleSetNewStatus(todo.id,e.target.value)}
                     w="8px"
                   >
                     <option value="着手前">着手前</option>
@@ -167,8 +160,8 @@ const TodoList = () => {
 
                 <Td color={renderPriority(todo)}>
                   <select
-                    // value={newPriority}
-                    // onChange={handleSetNewPriority}
+                    value={todo.priority}
+                    onChange={(e)=>handleSetNewPriority(todo.id,e.target.value)}
                     w="8px"
                   >
                     <option value="高">高</option>

--- a/pages/components/TodoList.js
+++ b/pages/components/TodoList.js
@@ -59,43 +59,35 @@ const TodoList = () => {
   const [editId, setEditId] = useState();
   const [newStatus, setNewStatus] = useState();
   const [newPriority, setNewPriority] = useState();
-  
 
   // ステータスの実装
-  const handleSetNewStatus = (e) => {
-    setNewStatus(e.target.value);
+
+  const handleSetNewStatus = (id) => {
+    const foundTodo = todos.findIndex((todo) => todo.id === id);
+
+    const replaceItemAtIndex = (todos, foundTodo, newValue) => {
+      return [
+        ...todos.slice(0, foundTodo),
+        newValue,
+        ...todos.slice(foundTodo + 1),
+      ];
+    };
+
+    setTodos(() => {
+      if (todos[foundTodo].status) {
+        return replaceItemAtIndex(todos, foundTodo, {
+          ...todos[foundTodo],
+          status: "完了",
+        });
+      }
+    });
   };
-
-  const handleOpenEditStatus = ({ id, status }) => {
-    setEditId(id);
-    setIsEditable(true);
-    setNewStatus(status);
-    console.log(isEditable);
-    
-  };
-
-  const handleCloseEditStatus = () => {
-    setIsEditable(false);
-    setEditId();
-    setNewStatus();
-  };
-
-  // 編集フォームへの値のコピー
-  const handleEditStatus = () => {
-    setTodos(
-      [...todos].map((todo) =>
-        todo.id === editId ? { ...todo, status: newStatus } : todo
-      )
-    );
-
-    handleCloseEditStatus();
-    setEditId();
-    setNewStatus();
-  };
-
-  // console.log(todos);
 
   // 優先度の実装
+  const updateTodoPriority = (id) => {
+    const index = todos.find((todo) => todo.id === id);
+    setTodos(() => {});
+  };
   const handleSetNewPriority = (e) => {
     setNewPriority(e.target.value);
   };
@@ -104,8 +96,6 @@ const TodoList = () => {
     setEditId(id);
     setIsEditable(true);
     setNewPriority(priority);
-    console.log(isEditable);
-    
   };
 
   const handleCloseEditPriority = () => {
@@ -126,8 +116,7 @@ const TodoList = () => {
     setEditId();
     setNewPriority();
   };
-
-  // console.log(todos);
+  console.log(todos);
 
   return (
     <>
@@ -163,83 +152,30 @@ const TodoList = () => {
                     </Button>
                   </Link>
                 </Td>
-                {!isEditable ? (
-                  <Td color={renderStatus(todo)}>
-                    <Flex justifyContent="space-between">
-                      <Text lineHeight="32.5px">{todo.status}</Text>
-                      <Button
-                        p="16px"
-                        size="sm"
-                        onClick={() => handleOpenEditStatus(todo)}
-                        value="edit"
-                      >
-                        編集
-                      </Button>
-                    </Flex>
-                  </Td>
-                ) : (
-                  <Td color={renderStatus(todo)}>
-                    <Flex justifyContent="space-between">
-                      <select
-                        value={newStatus}
-                        onChange={handleSetNewStatus}
-                        w="8px"
-                      >
-                        <option value="着手前">着手前</option>
-                        <option value="進行中">進行中</option>
-                        <option value="完了">完了</option>
-                      </select>
 
-                      <Button
-                        p="16px"
-                        size="sm"
-                        onClick={() => handleEditStatus()}
-                        value="save"
-                      >
-                        保存
-                      </Button>
-                    </Flex>
-                  </Td>
-                )}
+                <Td color={renderStatus(todo)}>
+                  <select
+                    // value={}
+                    onChange={(e) => handleSetNewStatus(todo.id)}
+                    w="8px"
+                  >
+                    <option value="着手前">着手前</option>
+                    <option value="進行中">進行中</option>
+                    <option value="完了">完了</option>
+                  </select>
+                </Td>
 
-                {!isEditable ? (
-                  <Td color={renderPriority(todo)}>
-                    <Flex justifyContent="space-between">
-                      <Text lineHeight="32.5px">{todo.priority}</Text>
-                      <Button
-                        p="16px"
-                        size="sm"
-                        onClick={() => handleOpenEditPriority(todo)}
-                        value="edit"
-                      >
-                        編集
-                      </Button>
-                    </Flex>
-                  </Td>
-                ) : (
-                  <Td color={renderPriority(todo)}>
-                    <Flex justifyContent="space-between">
-                      <select
-                        value={newPriority}
-                        onChange={handleSetNewPriority}
-                        w="8px"
-                      >
-                        <option value="高">高</option>
-                        <option value="中">中</option>
-                        <option value="低">低</option>
-                      </select>
-
-                      <Button
-                        p="16px"
-                        size="sm"
-                        onClick={() => handleEditPriority()}
-                        value="save"
-                      >
-                        保存
-                      </Button>
-                    </Flex>
-                  </Td>
-                )}
+                <Td color={renderPriority(todo)}>
+                  <select
+                    // value={newPriority}
+                    // onChange={handleSetNewPriority}
+                    w="8px"
+                  >
+                    <option value="高">高</option>
+                    <option value="中">中</option>
+                    <option value="低">低</option>
+                  </select>
+                </Td>
 
                 {/* <Td color={renderPriority(todo)}>{todo.priority}</Td> */}
                 <Td>{todo.createDate}</Td>

--- a/pages/components/TodoList.js
+++ b/pages/components/TodoList.js
@@ -1,12 +1,10 @@
 import Link from "next/link";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilValue } from "recoil";
 import { EditIcon } from "@chakra-ui/icons";
 import {
   Button,
   Checkbox,
   Container,
-  Flex,
-  Grid,
   Select,
   Table,
   Tbody,
@@ -18,10 +16,11 @@ import {
 } from "@chakra-ui/react";
 
 import { todosState } from "../atoms/atom";
-import { useState } from "react";
+import StatusSelect from "./atoms/StatusSelect";
+import PrioritySelect from "./atoms/PrioritySelect";
 
 const TodoList = () => {
-  const [todos, setTodos] = useRecoilState(todosState);
+  const todos = useRecoilValue(todosState);
 
   const renderStatus = (todo) => {
     switch (todo.status) {
@@ -55,60 +54,6 @@ const TodoList = () => {
     }
   };
 
-  const [isEditable, setIsEditable] = useState(false);
-  const [editId, setEditId] = useState();
-  const [newStatus, setNewStatus] = useState();
-  const [newPriority, setNewPriority] = useState();
-
-  // ステータスの実装
-
-  const handleSetNewStatus = (id,staus) => {
-    
-    const foundTodo = todos.findIndex((todo) => todo.id === id);
-
-    const replaceItemAtIndex = (todos, foundTodo, newValue) => {
-      return [
-        ...todos.slice(0, foundTodo),
-        newValue,
-        ...todos.slice(foundTodo + 1),
-      ];
-    };
-
-    setTodos(() => {
-      if (todos[foundTodo].status) {
-        return replaceItemAtIndex(todos, foundTodo, {
-          ...todos[foundTodo],
-          status: staus,
-        });
-      }
-    });
-  };
-
-  
-  // 優先度の実装
-  const handleSetNewPriority = (id,priority) => {
-    
-    const foundTodo = todos.findIndex((todo) => todo.id === id);
-    
-    const replaceItemAtIndex = (todos, foundTodo, newValue) => {
-      return [
-        ...todos.slice(0, foundTodo),
-        newValue,
-        ...todos.slice(foundTodo + 1),
-      ];
-    };
-    
-    setTodos(() => {
-      if (todos[foundTodo].priority) {
-        return replaceItemAtIndex(todos, foundTodo, {
-          ...todos[foundTodo],
-          priority: priority,
-        });
-      }
-    });
-    console.log();
-  };
-  
   console.log(todos);
 
   return (
@@ -147,30 +92,13 @@ const TodoList = () => {
                 </Td>
 
                 <Td color={renderStatus(todo)}>
-                  <select
-                    value={todo.status}
-                    onChange={(e) => handleSetNewStatus(todo.id,e.target.value)}
-                    w="8px"
-                  >
-                    <option value="着手前">着手前</option>
-                    <option value="進行中">進行中</option>
-                    <option value="完了">完了</option>
-                  </select>
+                  <StatusSelect todo={todo} />
                 </Td>
 
                 <Td color={renderPriority(todo)}>
-                  <select
-                    value={todo.priority}
-                    onChange={(e)=>handleSetNewPriority(todo.id,e.target.value)}
-                    w="8px"
-                  >
-                    <option value="高">高</option>
-                    <option value="中">中</option>
-                    <option value="低">低</option>
-                  </select>
+                  <PrioritySelect todo={todo} />
                 </Td>
 
-                {/* <Td color={renderPriority(todo)}>{todo.priority}</Td> */}
                 <Td>{todo.createDate}</Td>
                 <Td>{todo.updateDate}</Td>
               </Tr>

--- a/pages/components/TodoList.js
+++ b/pages/components/TodoList.js
@@ -58,8 +58,10 @@ const TodoList = () => {
   const [isEditable, setIsEditable] = useState(false);
   const [editId, setEditId] = useState();
   const [newStatus, setNewStatus] = useState();
+  const [newPriority, setNewPriority] = useState();
   
 
+  // ステータスの実装
   const handleSetNewStatus = (e) => {
     setNewStatus(e.target.value);
   };
@@ -89,6 +91,40 @@ const TodoList = () => {
     handleCloseEditStatus();
     setEditId();
     setNewStatus();
+  };
+
+  // console.log(todos);
+
+  // 優先度の実装
+  const handleSetNewPriority = (e) => {
+    setNewPriority(e.target.value);
+  };
+
+  const handleOpenEditPriority = ({ id, priority }) => {
+    setEditId(id);
+    setIsEditable(true);
+    setNewPriority(priority);
+    console.log(isEditable);
+    
+  };
+
+  const handleCloseEditPriority = () => {
+    setIsEditable(false);
+    setEditId();
+    setNewStatus();
+  };
+
+  // 編集フォームへの値のコピー
+  const handleEditPriority = () => {
+    setTodos(
+      [...todos].map((todo) =>
+        todo.id === editId ? { ...todo, priority: newPriority } : todo
+      )
+    );
+
+    handleCloseEditPriority();
+    setEditId();
+    setNewPriority();
   };
 
   // console.log(todos);
@@ -166,7 +202,46 @@ const TodoList = () => {
                   </Td>
                 )}
 
-                <Td color={renderPriority(todo)}>{todo.priority}</Td>
+                {!isEditable ? (
+                  <Td color={renderPriority(todo)}>
+                    <Flex justifyContent="space-between">
+                      <Text lineHeight="32.5px">{todo.priority}</Text>
+                      <Button
+                        p="16px"
+                        size="sm"
+                        onClick={() => handleOpenEditPriority(todo)}
+                        value="edit"
+                      >
+                        編集
+                      </Button>
+                    </Flex>
+                  </Td>
+                ) : (
+                  <Td color={renderPriority(todo)}>
+                    <Flex justifyContent="space-between">
+                      <select
+                        value={newPriority}
+                        onChange={handleSetNewPriority}
+                        w="8px"
+                      >
+                        <option value="高">高</option>
+                        <option value="中">中</option>
+                        <option value="低">低</option>
+                      </select>
+
+                      <Button
+                        p="16px"
+                        size="sm"
+                        onClick={() => handleEditPriority()}
+                        value="save"
+                      >
+                        保存
+                      </Button>
+                    </Flex>
+                  </Td>
+                )}
+
+                {/* <Td color={renderPriority(todo)}>{todo.priority}</Td> */}
                 <Td>{todo.createDate}</Td>
                 <Td>{todo.updateDate}</Td>
               </Tr>

--- a/pages/components/TodoList.js
+++ b/pages/components/TodoList.js
@@ -1,81 +1,180 @@
 import Link from "next/link";
-import { useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { EditIcon } from "@chakra-ui/icons";
-import { Button, Checkbox, Container, Table, Tbody, Td, Text, Th, Thead, Tr } from "@chakra-ui/react";
+import {
+  Button,
+  Checkbox,
+  Container,
+  Flex,
+  Grid,
+  Select,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
 
 import { todosState } from "../atoms/atom";
+import { useState } from "react";
 
 const TodoList = () => {
-  const todos = useRecoilValue(todosState);
+  const [todos, setTodos] = useRecoilState(todosState);
 
   const renderStatus = (todo) => {
-    switch(todo.status) {
-      case '着手前':
-        return 'orange';
+    switch (todo.status) {
+      case "着手前":
+        return "orange";
         break;
 
-      case '進行中':
-        return 'skyblue'
+      case "進行中":
+        return "skyblue";
         break;
 
-      case '完了':
-        return 'green'
+      case "完了":
+        return "green";
         break;
     }
-  }
+  };
 
   const renderPriority = (todo) => {
-    switch(todo.priority) {
-      case '低':
-        return 'green';
+    switch (todo.priority) {
+      case "低":
+        return "green";
         break;
 
-      case '中':
-        return 'yellow.400'
+      case "中":
+        return "yellow.400";
         break;
 
-      case '高':
-        return 'red'
+      case "高":
+        return "red";
         break;
     }
-  }
+  };
+
+  const [isEditable, setIsEditable] = useState(false);
+  const [editId, setEditId] = useState();
+  const [newStatus, setNewStatus] = useState();
+  
+
+  const handleSetNewStatus = (e) => {
+    setNewStatus(e.target.value);
+  };
+
+  const handleOpenEditStatus = ({ id, status }) => {
+    setEditId(id);
+    setIsEditable(true);
+    setNewStatus(status);
+    console.log(isEditable);
+    
+  };
+
+  const handleCloseEditStatus = () => {
+    setIsEditable(false);
+    setEditId();
+    setNewStatus();
+  };
+
+  // 編集フォームへの値のコピー
+  const handleEditStatus = () => {
+    setTodos(
+      [...todos].map((todo) =>
+        todo.id === editId ? { ...todo, status: newStatus } : todo
+      )
+    );
+
+    handleCloseEditStatus();
+    setEditId();
+    setNewStatus();
+  };
+
+  // console.log(todos);
 
   return (
-    <Container h='100%' maxW='100%' mt='5'>
-      <Table>
-        <Thead bg='gray.100'>
-          <Tr>
-            <Th>タスク名</Th>
-            <Th>ステータス</Th>
-            <Th>優先度</Th>
-            <Th>作成日時</Th>
-            <Th>更新日時</Th>
-          </Tr>
-        </Thead>
-
-        <Tbody>
-          {todos.map((todo) => (
-            <Tr key={todo.id}>
-              <Td display='flex' justifyContent='space-between'>
-                <Checkbox />
-                <Link href={`/todos/${todo.id}`} passHref>
-                  <Text cursor='pointer' _hover={{opacity: 0.7}}>
-                    {todo.title}
-                  </Text>
-                </Link>
-                <Link href={`/todos/${todo.id}/edittask`} passHref>
-                  <Button size='xs' colorScheme='teal' variant='outline'><EditIcon /></Button>
-                </Link>
-              </Td>
-              <Td color={renderStatus(todo)}>{todo.status}</Td>
-              <Td color={renderPriority(todo)}>{todo.priority}</Td>
-              <Td>{todo.createDate}</Td>
-              <Td>{todo.updateDate}</Td>
+    <>
+      <Container h="100%" maxW="100%" mt="5">
+        <Table>
+          <Thead bg="gray.100">
+            <Tr>
+              <Th>タスク名</Th>
+              <Th>ステータス</Th>
+              <Th>優先度</Th>
+              <Th>作成日時</Th>
+              <Th>更新日時</Th>
             </Tr>
-          ))}
-        </Tbody>
-      </Table>
-    </Container>
+          </Thead>
+
+          <Tbody>
+            {todos.map((todo) => (
+              <Tr key={todo.id}>
+                <Td display="flex" justifyContent="space-between" h="65.5px">
+                  <Checkbox />
+                  <Link href={`/todos/${todo.id}`} passHref>
+                    <Text
+                      cursor="pointer"
+                      _hover={{ opacity: 0.7 }}
+                      lineHeight="32.5px"
+                    >
+                      {todo.title}
+                    </Text>
+                  </Link>
+                  <Link href={`/todos/${todo.id}/edittask`} passHref>
+                    <Button size="xs" colorScheme="teal" variant="outline">
+                      <EditIcon />
+                    </Button>
+                  </Link>
+                </Td>
+                {!isEditable ? (
+                  <Td color={renderStatus(todo)}>
+                    <Flex justifyContent="space-between">
+                      <Text lineHeight="32.5px">{todo.status}</Text>
+                      <Button
+                        p="16px"
+                        size="sm"
+                        onClick={() => handleOpenEditStatus(todo)}
+                        value="edit"
+                      >
+                        編集
+                      </Button>
+                    </Flex>
+                  </Td>
+                ) : (
+                  <Td color={renderStatus(todo)}>
+                    <Flex justifyContent="space-between">
+                      <select
+                        value={newStatus}
+                        onChange={handleSetNewStatus}
+                        w="8px"
+                      >
+                        <option value="着手前">着手前</option>
+                        <option value="進行中">進行中</option>
+                        <option value="完了">完了</option>
+                      </select>
+
+                      <Button
+                        p="16px"
+                        size="sm"
+                        onClick={() => handleEditStatus()}
+                        value="save"
+                      >
+                        保存
+                      </Button>
+                    </Flex>
+                  </Td>
+                )}
+
+                <Td color={renderPriority(todo)}>{todo.priority}</Td>
+                <Td>{todo.createDate}</Td>
+                <Td>{todo.updateDate}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </Container>
+    </>
   );
 };
 

--- a/pages/components/TodoList.js
+++ b/pages/components/TodoList.js
@@ -54,7 +54,7 @@ const TodoList = () => {
     }
   };
 
-  console.log(todos);
+  
 
   return (
     <>

--- a/pages/components/atoms/PrioritySelect.jsx
+++ b/pages/components/atoms/PrioritySelect.jsx
@@ -23,7 +23,7 @@ const PrioritySelect = ({ todo }) => {
         });
       }
     });
-    console.log();
+   
   };
   return (
     <select

--- a/pages/components/atoms/PrioritySelect.jsx
+++ b/pages/components/atoms/PrioritySelect.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useRecoilState } from "recoil";
+import { todosState } from "../../atoms/atom";
+
+const PrioritySelect = ({ todo }) => {
+  const [todos, setTodos] = useRecoilState(todosState);
+  const handleSetNewPriority = (id, priority) => {
+    const foundTodo = todos.findIndex((todo) => todo.id === id);
+
+    const replaceItemAtIndex = (todos, foundTodo, newValue) => {
+      return [
+        ...todos.slice(0, foundTodo),
+        newValue,
+        ...todos.slice(foundTodo + 1),
+      ];
+    };
+
+    setTodos(() => {
+      if (todos[foundTodo].priority) {
+        return replaceItemAtIndex(todos, foundTodo, {
+          ...todos[foundTodo],
+          priority: priority,
+        });
+      }
+    });
+    console.log();
+  };
+  return (
+    <select
+      value={todo.priority}
+      onChange={(e) => handleSetNewPriority(todo.id, e.target.value)}
+      style={{ outline: "none" }}
+    >
+      <option value="高">高</option>
+      <option value="中">中</option>
+      <option value="低">低</option>
+    </select>
+  );
+};
+
+export default PrioritySelect;

--- a/pages/components/atoms/StatusSelect.jsx
+++ b/pages/components/atoms/StatusSelect.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { useRecoilState } from "recoil";
+import { todosState } from "../../atoms/atom";
+
+const StatusSelect = ({ todo }) => {
+  const [todos, setTodos] = useRecoilState(todosState);
+  const handleSetNewStatus = (id, staus) => {
+    const foundTodo = todos.findIndex((todo) => todo.id === id);
+
+    const replaceItemAtIndex = (todos, foundTodo, newValue) => {
+      return [
+        ...todos.slice(0, foundTodo),
+        newValue,
+        ...todos.slice(foundTodo + 1),
+      ];
+    };
+
+    setTodos(() => {
+      if (todos[foundTodo].status) {
+        return replaceItemAtIndex(todos, foundTodo, {
+          ...todos[foundTodo],
+          status: staus,
+        });
+      }
+    });
+  };
+  return (
+    <>
+      <select
+        value={todo.status}
+        onChange={(e) => handleSetNewStatus(todo.id, e.target.value)}
+        style={{ outline: "none" }}
+      >
+        <option value="着手前">着手前</option>
+        <option value="進行中">進行中</option>
+        <option value="完了">完了</option>
+      </select>
+    </>
+  );
+};
+
+export default StatusSelect;


### PR DESCRIPTION
## IssueのURL
close #10
## 対応内容・対応背景・妥協点
[対応内容]
一覧画面からステータスと優先度の編集機能の追加
## やったこと
一覧画面のステータスと優先度のセレクトボックスを作成。セレクトボックスで値を変更するとTodos内のそれぞれの値を変更する機能を実装。

## やってないこと・できていないこと
chakra uiで<Select>を使おうとしたが、選択しても文字が表示されなかったため通常の<select>タグを使用。
StatusSelect.jsxとPrioritySelect.jsx内の関数の内容がほとんど同じで最適化ができそうだったが、後回しにした。

## UI before / after

https://user-images.githubusercontent.com/88872593/154904014-21873b18-fd82-43d3-b95d-b8f82fe0356e.mov

## テスト

## レビュー観点
あくまで目安です。

- 想定通りに動作するか？
- より良いJS/JSX/TS/TSX/CSS/Reactの書き方はないか？
- より良い設計方法はないか？
- 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- 関数、コンポーネントの粒度は適切か？
- etc...

## 補足

※必要な項目だけ使用し、不要なものは削除すること
